### PR TITLE
Fixed bug in mail.c causing https://github.com/justanhduc/task-spooler/issues/24

### DIFF
--- a/mail.c
+++ b/mail.c
@@ -50,7 +50,7 @@ static void write_header(int fd, const char *dest, const char *command,
     fd_nprintf(fd, 500, "To: %s\n", dest);
     fd_nprintf(fd, 500, "Subject: the task %i finished with error %i. \n", jobid,
                errorlevel);
-    fd_nprintf(fd, 12+(int)strlen(command), "\nCommand: %s\n", command);
+    fd_nprintf(fd, 13+(int)strlen(command), "\nCommand: %s\n", command);
     fd_nprintf(fd, 500, "Output:\n");
 }
 


### PR DESCRIPTION
Still put out garbage at over 500 characters. Reproducible with:
`tsp -m echo loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong`

Causes:
`From: Task Spooler <taskspooler>
To: root
Subject: the task 2 finished with error 0.

Command: echo looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo^@^@^@^@^@¡^C^B^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@Output:
loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong`