### PR TITLE
Implements the changes to allow 'ts -s 0', to gracefully end current active jobs and not start any new jobs

### DIFF
--- a/jobs.c
+++ b/jobs.c
@@ -1585,7 +1585,7 @@ void s_wait_running_job(int s, int jobid) {
 }
 
 void s_set_max_slots(int new_max_slots) {
-    if (new_max_slots > 0)
+    if (new_max_slots >= 0)  /* -S 0 lets active jobs end without starting new ones. */
         max_slots = new_max_slots;
     else
         warning("Received new_max_slots=%i", new_max_slots);

--- a/main.c
+++ b/main.c
@@ -290,8 +290,8 @@ void parse_opts(int argc, char **argv) {
             case 'S':
                 command_line.request = c_SET_MAX_SLOTS;
                 command_line.max_slots = atoi(optarg);
-                if (command_line.max_slots < 1) {
-                    fprintf(stderr, "You should set at minimum 1 slot.\n");
+                if (command_line.max_slots < 0) { /* -S 0 lets active jobs end without starting new ones. */
+                    fprintf(stderr, "You should set to 0 or more slots.\n"); /* was: You should set at minimum 1 slot.\n */
                     exit(-1);
                 }
                 break;


### PR DESCRIPTION
Implements the changes to allow 'ts -s 0', so one can gracefully end current active jobs and not start any new jobs. 
Changes were suggested in feature request here: https://github.com/justanhduc/task-spooler/issues/69